### PR TITLE
cb() not function error.

### DIFF
--- a/src/bjson.js
+++ b/src/bjson.js
@@ -30,7 +30,7 @@ let bjson = (file, cb) => {
   observe = observed(parsed);
 
   observe.on('change', () => {
-    steno.writeFile(file, JSON.stringify(parsed, null, '\t'));
+    steno.writeFileSync(file, JSON.stringify(parsed, null, '\t'));
   });
 
   if(typeof cb === "function") {


### PR DESCRIPTION
steno.writeFile requires a call back which is currently not sent. writeFile seems to have been mistakenly used instead of writeFileSync.
